### PR TITLE
Support embedded-hal v0.2 for i2c

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,16 @@ checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "embedded-hal"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35949884794ad573cf46071e41c9b60efb0cb311e3ca01f7af807af1debc66ff"
+dependencies = [
+ "nb 0.1.3",
+ "void",
+]
+
+[[package]]
+name = "embedded-hal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
@@ -40,6 +50,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nb"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
+dependencies = [
+ "nb 1.1.0",
+]
+
+[[package]]
+name = "nb"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,11 +80,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
 name = "wasi-embedded-hal"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitflags",
- "embedded-hal",
+ "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
  "lol_alloc",
  "wit-bindgen-rt",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,16 +6,19 @@ keywords = ["Wasm", "hal"]
 license = "Apache-2.0"
 name = "wasi-embedded-hal"
 repository = "https://github.com/Zelzahn/wasi-embedded-hal"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [dependencies]
 bitflags = "2.4.2"
-embedded-hal = "1.0.0"
+embedded-hal-1_0 = { version = "1.0.0", optional = true, package = "embedded-hal" }
+embedded-hal-0_2 = { version = "0.2.7", optional = true, package = "embedded-hal" }
 lol_alloc = "0.4.1"
-wit-bindgen-rt = "0.22.0"
+wit-bindgen-rt = "0.24.0"
 
 [features]
-default = ["use_std"]
+default = ["use_std", "hal_1_0"]
 use_std = ["use_alloc"]
 use_alloc = []
+hal_1_0 = ["dep:embedded-hal-1_0"]
+hal_0_2 = ["dep:embedded-hal-0_2"]

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -2,6 +2,7 @@
 //!
 //! [`embedded-hal`]: https://docs.rs/embedded-hal
 
+#[cfg(feature = "hal_1_0")]
 #[macro_export]
 macro_rules! add_delay_hal {
     ($delay: ident) => {

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -2,7 +2,8 @@
 //!
 //! [`embedded-hal`]: https://docs.rs/embedded-hal
 
-/// Macro that adds HAL support for a given I2C bindings.
+/// Macro that adds HAL 1.0 support for a given I2C bindings.
+#[cfg(feature = "hal_1_0")]
 #[macro_export]
 macro_rules! add_i2c_hal {
     ($i2c:ident) => {
@@ -96,6 +97,91 @@ macro_rules! add_i2c_hal {
                 &mut self,
                 address: u8,
                 operations: &mut [HalOperation<'_>],
+            ) -> Result<(), Self::Error> {
+                let opers = operations
+                    .iter_mut()
+                    .map(|a| match a {
+                        HalOperation::Read(r) => Operation::Read(r.len().try_into().unwrap()),
+                        HalOperation::Write(w) => Operation::Write(w.to_vec()),
+                    })
+                    .collect::<Vec<Operation>>();
+
+                let _ = Self::transaction(self, u16::from(address), &opers);
+
+                Ok(())
+            }
+        }
+    };
+}
+
+/// Macro that adds HAL 0.2 support for a given I2C bindings.
+#[cfg(feature = "hal_0_2")]
+#[macro_export]
+macro_rules! add_i2c_hal {
+    ($i2c:ident) => {
+        use embedded_hal::blocking::i2c::Operation as HalOperation;
+        use $i2c::{ErrorCode, I2c, NoAcknowledgeSource, Operation};
+
+        #[derive(Debug)]
+        pub struct I2CError {
+            err: ErrorCode,
+        }
+
+        impl embedded_hal::blocking::i2c::Read for I2c {
+            type Error = I2CError;
+
+            fn read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Self::Error> {
+                let data = Self::read(&self, u16::from(address), read.len().try_into().unwrap())
+                    .map_err(|e| I2CError { err: e })?;
+
+                for (read, data) in read.iter_mut().zip(data) {
+                    *read = data;
+                }
+
+                Ok(())
+            }
+        }
+
+        impl embedded_hal::blocking::i2c::Write for I2c {
+            type Error = I2CError;
+
+            fn write(&mut self, address: u8, write: &[u8]) -> Result<(), Self::Error> {
+                Self::write(&self, u16::from(address), write).map_err(|e| I2CError { err: e })
+            }
+        }
+
+        impl embedded_hal::blocking::i2c::WriteRead for I2c {
+            type Error = I2CError;
+
+            fn write_read(
+                &mut self,
+                address: u8,
+                write: &[u8],
+                read: &mut [u8],
+            ) -> Result<(), Self::Error> {
+                let data = Self::write_read(
+                    &self,
+                    u16::from(address),
+                    write,
+                    read.len().try_into().unwrap(),
+                )
+                .map_err(|e| I2CError { err: e })?;
+
+                for (read, data) in read.iter_mut().zip(data) {
+                    *read = data;
+                }
+
+                Ok(())
+            }
+        }
+
+        impl embedded_hal::blocking::i2c::Transactional for I2c {
+            type Error = I2CError;
+
+            fn exec<'a>(
+                &mut self,
+                address: u8,
+                operations: &mut [HalOperation<'a>],
             ) -> Result<(), Self::Error> {
                 let opers = operations
                     .iter_mut()


### PR DESCRIPTION
There are several crates that are still using embedded-hal v0.2, i.e. [vl53l1](https://github.com/mitchmindtree/vl53l1).
This PR provides i2c compatible with embedded-hal v0.2 through cargo feature "hal_0_2".